### PR TITLE
Aim at: Path must be a string.

### DIFF
--- a/tasks/responsive_images_extender.js
+++ b/tasks/responsive_images_extender.js
@@ -189,11 +189,11 @@ module.exports = function(grunt) {
         grunt.log.error('No files to process!');
         return;
       }
-
-      result = parseAndExtendImg(f.src);
-
-      grunt.file.write(f.dest, result.content);
-      imgCount += result.count;
+      f. src.forEach(function(src){
+        result = parseAndExtendImg(src);
+        grunt.file.write(f.dest, result.content);
+        imgCount += result.count;
+      })
     });
 
     grunt.log.ok('Processed ' + imgCount.toString().cyan + ' <img> ' + grunt.util.pluralize(imgCount, 'tag/tags'));


### PR DESCRIPTION
there is always an error throwed out: Path must be a string. I think the function named parseAndExtendImg need a string as the parameter, while f. src is an Array. Maybe a simple forEach will fix it.